### PR TITLE
fix(proxy): guard headersSent on upstream error (prevents pi crash)

### DIFF
--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -883,8 +883,12 @@ function startProxy(
 						},
 					);
 					proxy.on("error", () => {
-						res.writeHead(502, { "content-type": "application/json" });
-						res.end(JSON.stringify({ error: "upstream error" }));
+						if (!res.headersSent) {
+							res.writeHead(502, { "content-type": "application/json" });
+							res.end(JSON.stringify({ error: "upstream error" }));
+						} else if (!res.writableEnded) {
+							res.end();
+						}
 					});
 					proxy.setTimeout(30_000, () => {
 						proxy.destroy(new Error("timeout"));


### PR DESCRIPTION
## Problem
When an upstream bansos source drops the connection mid-response, the reverse proxy's request `error` listener calls `res.writeHead(502, ...)` even though headers were already sent by the upstream callback (`res.writeHead(statusCode, …)` + `upstream.pipe(res)`). That throws `ERR_HTTP_HEADERS_SENT`. Because the handler is an event listener (outside the surrounding `try/catch`), the exception is **uncaught and Node terminates the entire pi process**.

## Fix
Guard the handler the same way the rest of the proxy already guards mid-stream failures:

```js
proxy.on("error", () => {
  if (!res.headersSent) {
    res.writeHead(502, { "content-type": "application/json" });
    res.end(JSON.stringify({ error: "upstream error" }));
  } else if (!res.writableEnded) {
    res.end();
  }
});
```

## Repro
Any `bansos` model request where the upstream closes the connection after sending headers (rate-limit, `ETIMEDOUT`, `ECONNRESET` mid-stream) → `ERR_HTTP_HEADERS_SENT` → pi exits.

No behavioral change for the normal pre-header error path; only the already-sent case is handled gracefully.

A `0.4.3` npm publish would be appreciated so users get this without a local patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of proxy errors when a response has already started.
  * Prevented duplicate response headers and ensured incomplete responses are closed cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->